### PR TITLE
fix: Unlink a volume of an application meta container from

### DIFF
--- a/isolate/porto.go
+++ b/isolate/porto.go
@@ -450,7 +450,7 @@ func (pi *portoIsolation) Spool(ctx context.Context, image, tag string) error {
 		log.WithField("imageid", imageid).Infof("Created volume %v", volumeDescription)
 	}
 
-	// NOTE: create parent container
+	// NOTE: create a meta container for all the workers of an app
 	parentContainer := path.Join(pi.rootNamespace, appname)
 	err = portoConn.Create(parentContainer)
 	if err != nil {
@@ -461,12 +461,25 @@ func (pi *portoIsolation) Spool(ctx context.Context, image, tag string) error {
 		log.WithField("parent", parentContainer).Info("parent container already exists")
 	}
 
-	// Link a created voluume to the parent container
-	// It's just a ref counter
+	// NOTE: Link a created volume to the parent (meta application) container. It's just a ref counter.
+	// Also this volume has been already linked to a parent (root) namespace.
 	if err := portoConn.LinkVolume(volumePath, parentContainer); err != nil {
 		if !isEqualPortoError(err, portorpc.EError_VolumeAlreadyLinked) {
 			log.WithFields(log.Fields{"parent": parentContainer, "error": err, "volume": volumePath}).Error("unable to link volume")
 			return err
+		}
+	}
+
+	// NOTE: transfer the ownership of the volume for application meta container.
+	// Current links: `root_namespace` `root_namespace/app_meta_container_namespace`
+	// So unlink this volume from `root_namespace`
+	if pi.rootNamespace != "" {
+		if err := portoConn.UnlinkVolume(volumePath, pi.rootNamespace); err != nil {
+			if !isEqualPortoError(err, portorpc.EError_VolumeNotLinked) {
+				log.WithFields(log.Fields{"root": pi.rootNamespace, "error": err, "volume": volumePath}).Error("unable to unlink volume")
+				return err
+			}
+			log.WithFields(log.Fields{"root": pi.rootNamespace, "error": err, "volume": volumePath}).Warn("volume is not linked")
 		}
 	}
 
@@ -502,7 +515,7 @@ func (pi *portoIsolation) Create(ctx context.Context, profile Profile) (salt str
 	pi.containers[salt] = containerID
 	pi.mu.Unlock()
 
-	// NOTE: It's better to destroy container if something goes wrong
+	// NOTE: It's better to destroy a container if something goes wrong
 	// TODO: wrap into ScopeExit
 	defer func(containeID string) {
 		if err != nil {


### PR DESCRIPTION
a root namespace container if it's not "" to transfer ownership of the volume (see example):
LINKS: root, root/app_meta -> root/app_meta