### PR TITLE
Box: provide io.Writer to collect workers output

### DIFF
--- a/isolate/process/proc_bench_test.go
+++ b/isolate/process/proc_bench_test.go
@@ -34,9 +34,17 @@ func BenchmarkSpawnSeq(b *testing.B) {
 	}
 	defer box.Close()
 
+	config := isolate.SpawnConfig{
+		Opts:       isolate.Profile{},
+		Name:       appName,
+		Executable: executable,
+		Args:       map[string]string{},
+		Env:        nil,
+	}
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		p, err := box.Spawn(ctx, isolate.Profile{}, appName, executable, map[string]string{}, nil)
+		p, err := box.Spawn(ctx, config, ioutil.Discard)
 		if err != nil {
 			b.Fatal("Spawn error: ", err)
 		}
@@ -66,10 +74,18 @@ func BenchmarkSpawnParallel(b *testing.B) {
 	}
 	defer box.Close()
 
+	config := isolate.SpawnConfig{
+		Opts:       isolate.Profile{},
+		Name:       appName,
+		Executable: executable,
+		Args:       map[string]string{},
+		Env:        nil,
+	}
+
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			p, err := box.Spawn(ctx, isolate.Profile{}, appName, executable, map[string]string{}, nil)
+			p, err := box.Spawn(ctx, config, ioutil.Discard)
 			if err != nil {
 				b.Fatal("Spawn error: ", err)
 			}

--- a/isolate/process/process.go
+++ b/isolate/process/process.go
@@ -3,8 +3,6 @@ package process
 import (
 	"io"
 	"os/exec"
-	"path/filepath"
-	"sync/atomic"
 
 	"golang.org/x/net/context"
 
@@ -19,102 +17,31 @@ var (
 type process struct {
 	ctx context.Context
 	cmd *exec.Cmd
-
-	output chan isolate.ProcessOutput
 }
 
-func newProcess(ctx context.Context, executable string, args, env map[string]string, workDir string) (*process, error) {
+func newProcess(ctx context.Context, executable string, args, env []string, workDir string, output io.Writer) (*process, error) {
 	pr := process{
-		ctx:    ctx,
-		output: make(chan isolate.ProcessOutput, 10),
-	}
-
-	packedEnv := make([]string, 0, len(env))
-	for k, v := range env {
-		packedEnv = append(packedEnv, k+"="+v)
-	}
-
-	packedArgs := make([]string, 1, len(args)*2+1)
-	packedArgs[0] = filepath.Base(executable)
-	for k, v := range args {
-		packedArgs = append(packedArgs, k, v)
+		ctx: ctx,
 	}
 
 	pr.cmd = &exec.Cmd{
-		Env:         packedEnv,
-		Args:        packedArgs,
+		Env:         env,
+		Args:        args,
 		Dir:         workDir,
 		Path:        executable,
+		Stdout:      output,
+		Stderr:      output,
 		SysProcAttr: getSysProctAttr(),
-	}
-
-	// sme is used to keep track an order of output channel
-	var sem uint32
-
-	collector := func(r io.Reader) {
-		defer func() {
-			if atomic.AddUint32(&sem, 1) == 2 {
-				close(pr.output)
-			}
-		}()
-
-		for {
-			p := isolate.GetPreallocatedOutputChunk()
-			nn, err := r.Read(p)
-			if nn > 0 {
-				pr.output <- isolate.ProcessOutput{
-					Data: p[:nn],
-					Err:  nil,
-				}
-			}
-
-			if err != nil {
-				if err == io.EOF {
-					return
-				}
-				pr.output <- isolate.ProcessOutput{
-					Data: nil,
-					Err:  err,
-				}
-				return
-			}
-		}
-	}
-
-	// stdout
-	stdout, err := pr.cmd.StdoutPipe()
-	if err != nil {
-		apexctx.GetLogger(ctx).WithError(err).Errorf("unable to attach stdout of %s", pr.cmd.Path)
-		return nil, err
-	}
-
-	// stderr
-	stderr, err := pr.cmd.StderrPipe()
-	if err != nil {
-		apexctx.GetLogger(ctx).WithError(err).Errorf("unable to attach stderr of %s", pr.cmd.Path)
-		return nil, err
 	}
 
 	if err := pr.cmd.Start(); err != nil {
 		apexctx.GetLogger(ctx).WithError(err).Errorf("unable to start executable %s", pr.cmd.Path)
-		stdout.Close()
-		stderr.Close()
 		return nil, err
 	}
-
-	// NOTE: is it dangerous?
-	isolate.NotifyAbouStart(pr.output)
-	go collector(stdout)
-	go collector(stderr)
 	apexctx.GetLogger(ctx).WithField("pid", pr.cmd.Process.Pid).Info("executable has been launched")
-
 	return &pr, nil
 }
 
 func (p *process) Kill() error {
 	return p.cmd.Process.Kill()
-}
-
-func (p *process) Output() <-chan isolate.ProcessOutput {
-	return p.output
 }


### PR DESCRIPTION
Using io.Writer prevents memory copying and simplifies the implementation