### PR TITLE
bugfix(docker): handle \n n in the last line

### DIFF
--- a/isolate/docker/box.go
+++ b/isolate/docker/box.go
@@ -290,6 +290,9 @@ func decodeImagePull(ctx context.Context, r io.Reader) error {
 		case nil:
 			// pass
 		case io.EOF:
+			if len(line) == 0 {
+				return nil
+			}
 			more = false
 		default:
 			return err


### PR DESCRIPTION
Docker replies with jsonified lines of statuses. Even the last line will be finished with \n
Previously it was parsed as an empty line wih EOF, and treated as error.