### PR TITLE
Change default network type for porto isolation from "host" to "inher…

### DIFF
--- a/isolate/porto/container.go
+++ b/isolate/porto/container.go
@@ -70,10 +70,10 @@ func pickNetwork(network string) string {
 	// TODO: this function is useless now
 	// but we have to add more mapping later
 	switch network {
-	case "host":
+	case "inherited":
 		return network
 	default:
-		return "host"
+		return "inherited"
 	}
 }
 


### PR DESCRIPTION
…ited". Type "host" deprecated and soon will be purged in porto.