### PR TITLE
isolate(porto): add some porto limits

### DIFF
--- a/isolate/docker/profile.go
+++ b/isolate/docker/profile.go
@@ -36,6 +36,7 @@ type Profile struct {
 	Binds     []string          `json:"binds"`
 }
 
+// ConvertProfile unpacked general profile to a Docker specific
 func ConvertProfile(rawprofile isolate.Profile) (*Profile, error) {
 	// Create profile with default values
 	// They can be overwritten by decode

--- a/isolate/porto/container_test.go
+++ b/isolate/porto/container_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
+	"github.com/noxiouz/stout/isolate"
 	"github.com/noxiouz/stout/isolate/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,18 +36,23 @@ func TestExecInfoFormatters(t *testing.T) {
 			"envA": "A",
 			"envB": "B",
 		},
-		Profile: &docker.Profile{
-			RuntimePath: "/var/run",
-			NetworkMode: "host",
-			Cwd:         "/tmp",
-			Resources: docker.Resources{
-				Memory: 4 * 1024 * 1024,
-			},
-			Tmpfs: map[string]string{
-				"/tmp/a": "size=100000",
-			},
-			Binds: []string{"/tmp:/bind:rw"},
-		},
+		// Profile: &docker.Profile{
+		// 	RuntimePath: "/var/run",
+		// 	NetworkMode: "host",
+		// 	Cwd:         "/tmp",
+		// 	Resources: docker.Resources{
+		// 		Memory: 4 * 1024 * 1024,
+		// 	},
+		// 	Tmpfs: map[string]string{
+		// 		"/tmp/a": "size=100000",
+		// 	},
+		// 	Binds: []string{"/tmp:/bind:rw"},
+		// },
+		portoProfile: portoProfile{isolate.Profile{
+			"binds":        []string{"/tmp:/bind:rw"},
+			"cwd":          "/tmp",
+			"network_mode": "host",
+		}},
 	}
 
 	assert.Equal("/var/run/cocaine.sock /run/cocaine;/tmp /bind rw", formatBinds(&info))
@@ -136,7 +142,7 @@ func TestContainer(t *testing.T) {
 	}
 
 	ei := execInfo{
-		Profile:    &profile,
+		// Profile:    &profile,
 		name:       "TestContainer",
 		executable: "echo",
 		args:       map[string]string{"--endpoint": "/var/run/cocaine.sock"},

--- a/isolate/porto/profile.go
+++ b/isolate/porto/profile.go
@@ -1,0 +1,112 @@
+package porto
+
+import (
+	"fmt"
+
+	"github.com/noxiouz/stout/isolate"
+
+	apexctx "github.com/m0sth8/context"
+	"golang.org/x/net/context"
+
+	porto "github.com/yandex/porto/src/api/go"
+)
+
+type portoProfile struct {
+	isolate.Profile
+}
+
+func (p portoProfile) Binds() []string {
+	binds, ok := p.Profile["binds"]
+	if !ok {
+		return nil
+	}
+
+	switch binds := binds.(type) {
+	case []string:
+		return binds
+	case [][]byte:
+		bs := make([]string, 0, len(binds))
+		for _, b := range binds {
+			bs = append(bs, string(b))
+		}
+		return bs
+	default:
+		return nil
+	}
+}
+
+func (p portoProfile) Registry() string {
+	return getStringValue(p.Profile, "registry")
+}
+
+func (p portoProfile) Cwd() string {
+	return getStringValue(p.Profile, "cwd")
+}
+
+func (p portoProfile) NetworkMode() string {
+	return getStringValue(p.Profile, "network_mode")
+}
+
+func getStringValue(mp map[string]interface{}, key string) string {
+	value, ok := mp[key]
+	if !ok {
+		return ""
+	}
+
+	switch value := value.(type) {
+	case string:
+		return value
+	case []byte:
+		return string(value)
+	default:
+		return ""
+	}
+}
+
+func (p portoProfile) applyContainerLimits(ctx context.Context, portoConn porto.API, id string) error {
+	limits, ok := p.Profile["container"]
+	if !ok {
+		apexctx.GetLogger(ctx).WithField("container", id).Info("no container limits")
+		return nil
+	}
+
+	switch limits := limits.(type) {
+	case map[string]interface{}:
+		log := apexctx.GetLogger(ctx).WithField("container", id)
+		for limit, value := range limits {
+			strvalue := fmt.Sprintf("%s", value)
+			log.Debugf("apply %s %s", limit, strvalue)
+			if err := portoConn.SetProperty(id, limit, strvalue); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("invalid resources type %T", limits)
+	}
+}
+
+func (p portoProfile) applyVolumeLimits(ctx context.Context, id string, vp map[string]string) error {
+	limits, ok := p.Profile["volume"]
+	if !ok {
+		apexctx.GetLogger(ctx).WithField("container", id).Info("no volume limits")
+		return nil
+	}
+
+	switch limits := limits.(type) {
+	case map[string]interface{}:
+		log := apexctx.GetLogger(ctx).WithField("container", id)
+		for limit, value := range limits {
+			strvalue := fmt.Sprintf("%s", value)
+			log.Debugf("apply volume limit %s %s", limit, strvalue)
+			vp[limit] = strvalue
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("invalid resources type %T", limits)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Example:
```json
{
    "volume": {
      "space_limit": "50G",
      "inode_limit": "2000000"
    },
    "container": {
      "memory_limit": "4000000000",
      "cpu_limit": "2c"
    },
    "registry": "http://registry.net"
}
```