### PR TITLE
Basci workers stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LDFLAGS=-ldflags "-X github.com/noxiouz/stout/version.GitTag=${TAG} -X github.co
 
 
 .DEFAULT: all
-.PHONY: fmt vet test
+.PHONY: fmt vet test gen_msgp
 
 PKGS := $(shell go list ./... | grep -v ^github.com/noxiouz/stout/vendor/ | grep -v ^github.com/noxiouz/stout/version)
 
@@ -32,11 +32,14 @@ test:
 		cat profile.out >> coverage.txt; rm  profile.out; \
 	fi done; \
 
-build:
+build: gen_msgp
 	@echo "+ $@"
 	go build ${LDFLAGS} -o ${NAME} github.com/noxiouz/stout/cmd/stout
 
-build_travis_release:
+build_travis_release: gen_msgp
 	@echo "+ $@"
 	env GOOS="linux" go build ${LDFLAGS} -o ${NAME} github.com/noxiouz/stout/cmd/stout
 	env GOOS="darwin" go build ${LDFLAGS} -o ${NAME}_osx github.com/noxiouz/stout/cmd/stout
+
+gen_msgp:
+	@cd ./isolate; go generate; cd ..

--- a/isolate/conn_handler.go
+++ b/isolate/conn_handler.go
@@ -220,7 +220,8 @@ func (r *responseStream) close(ctx context.Context) {
 	}
 }
 
-func (r *responseStream) Write(ctx context.Context, num uint64, data []byte) error {
+// Writes messagepacked payload `as is` as a packet of Cocaine
+func (r *responseStream) WriteMessage(ctx context.Context, num uint64, packedPayload []byte) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -238,13 +239,22 @@ func (r *responseStream) Write(ctx context.Context, num uint64, data []byte) err
 	p = msgp.AppendUint64(p, num)
 
 	p = msgp.AppendArrayHeader(p, 1)
-	p = msgp.AppendStringFromBytes(p, data)
+	p = append(p, packedPayload...)
 
 	if _, err := r.wr.Write(p); err != nil {
 		log.G(r.ctx).WithError(err).Error("responseStream.Write")
 		return err
 	}
 	return nil
+}
+
+// IMHO: should be named WriteString, really.
+func (r *responseStream) Write(ctx context.Context, num uint64, str []byte) error {
+	p := msgpackBytePool.Get().([]byte)[:0]
+	defer msgpackBytePool.Put(p)
+
+	p = msgp.AppendStringFromBytes(p, str)
+	return r.WriteMessage(ctx, num, p)
 }
 
 func (r *responseStream) Error(ctx context.Context, num uint64, code [2]int, msg string) error {

--- a/isolate/container_metrics.go
+++ b/isolate/container_metrics.go
@@ -1,5 +1,5 @@
 //go:generate msgp --tests=false
-//msgp:ignore isolate.MarkedContainerMetrics
+//msgp:ignore isolate.MarkedWorkerMetrics
 package isolate
 
 type (
@@ -8,7 +8,7 @@ type (
 		TxBytes uint64 `msg:"tx_bytes"`
 	}
 
-	ContainerMetrics struct {
+	WorkerMetrics struct {
 		UptimeSec uint64 `msg:"uptime"`
 		CpuUsageSec uint64 `msg:"cpu_usage"`
 
@@ -20,19 +20,19 @@ type (
 		Net map[string]NetStat `msg:"net"`
 	}
 
-	MetricsResponse map[string]*ContainerMetrics
+	MetricsResponse map[string]*WorkerMetrics
 
-	MarkedContainerMetrics struct {
+	MarkedWorkerMetrics struct {
 		uuid string
-		m *ContainerMetrics
+		m *WorkerMetrics
 	}
 )
 
-func NewContainerMetrics() (c ContainerMetrics) {
+func NewWorkerMetrics() (c WorkerMetrics) {
 	c.Net = make(map[string]NetStat)
 	return
 }
 
-func NewMarkedMetrics(uuid string, cm *ContainerMetrics) MarkedContainerMetrics {
-	return MarkedContainerMetrics{uuid: uuid, m: cm}
+func NewMarkedMetrics(uuid string, cm *WorkerMetrics) MarkedWorkerMetrics {
+	return MarkedWorkerMetrics{uuid: uuid, m: cm}
 }

--- a/isolate/container_metrics.go
+++ b/isolate/container_metrics.go
@@ -1,0 +1,37 @@
+//go:generate msgp --tests=false
+//msgp:ignore isolate.MarkedContainerMetrics
+package isolate
+
+type (
+	NetStat struct {
+		RxBytes, TxBytes uint64
+	}
+
+	ContainerMetrics struct {
+		UptimeSec uint64
+
+		CpuUsageNs uint64
+		CpuLoad float64
+
+		Mem uint64
+
+		// iface -> net stat
+		Net map[string]NetStat
+	}
+
+	MetricsResponse map[string]*ContainerMetrics
+
+	MarkedContainerMetrics struct {
+		uuid string
+		m *ContainerMetrics
+	}
+)
+
+func NewContainerMetrics() (c ContainerMetrics) {
+	c.Net = make(map[string]NetStat)
+	return
+}
+
+func NewMarkedMetrics(uuid string, cm *ContainerMetrics) MarkedContainerMetrics {
+	return MarkedContainerMetrics{uuid: uuid, m: cm}
+}

--- a/isolate/container_metrics.go
+++ b/isolate/container_metrics.go
@@ -4,19 +4,20 @@ package isolate
 
 type (
 	NetStat struct {
-		RxBytes, TxBytes uint64
+		RxBytes uint64 `msg:"rx_bytes"`
+		TxBytes uint64 `msg:"tx_bytes"`
 	}
 
 	ContainerMetrics struct {
-		UptimeSec uint64
+		UptimeSec uint64 `msg:"uptime"`
+		CpuUsageSec uint64 `msg:"cpu_usage"`
 
-		CpuUsageNs uint64
-		CpuLoad float64
+		CpuLoad float64 `msg:"cpu_load"`
 
-		Mem uint64
+		Mem uint64 `msg:"mem"`
 
 		// iface -> net stat
-		Net map[string]NetStat
+		Net map[string]NetStat `msg:"net"`
 	}
 
 	MetricsResponse map[string]*ContainerMetrics

--- a/isolate/docker/box.go
+++ b/isolate/docker/box.go
@@ -254,6 +254,10 @@ func (b *Box) Inspect(ctx context.Context, workeruuid string) ([]byte, error) {
 	return []byte("{}"), nil
 }
 
+func (b *Box) QueryMetrics(uuids []string) (r []isolate.MarkedContainerMetrics) {
+	return
+}
+
 // Spool spools an image with a tag latest
 func (b *Box) Spool(ctx context.Context, name string, opts isolate.RawProfile) (err error) {
 	profile, err := decodeProfile(opts)

--- a/isolate/docker/box.go
+++ b/isolate/docker/box.go
@@ -254,7 +254,8 @@ func (b *Box) Inspect(ctx context.Context, workeruuid string) ([]byte, error) {
 	return []byte("{}"), nil
 }
 
-func (b *Box) QueryMetrics(uuids []string) (r []isolate.MarkedContainerMetrics) {
+func (b *Box) QueryMetrics(uuids []string) (r []isolate.MarkedWorkerMetrics) {
+	// Not implemented yet
 	return
 }
 

--- a/isolate/errors.go
+++ b/isolate/errors.go
@@ -20,7 +20,7 @@ const (
 	codeOutputError
 	codeKillError
 	codeSpoolCancellationError
-	codeContainerMetricsFailed
+	codeWorkerMetricsFailed
 	codeMarshallingError
 )
 
@@ -33,7 +33,7 @@ var (
 	errOutputError            = [2]int{isolateErrCategory, codeOutputError}
 	errKillError              = [2]int{isolateErrCategory, codeKillError}
 	errSpoolCancellationError = [2]int{isolateErrCategory, codeSpoolCancellationError}
-	errContainerMetricsFailed = [2]int{isolateErrCategory, codeContainerMetricsFailed}
+	errWorkerMetricsFailed    = [2]int{isolateErrCategory, codeWorkerMetricsFailed}
 	errMarshallingError       = [2]int{isolateErrCategory, codeMarshallingError}
 	errSpawnEAGAIN            = [2]int{systemCategory, codeSpawnEAGAIN}
 )

--- a/isolate/errors.go
+++ b/isolate/errors.go
@@ -20,6 +20,8 @@ const (
 	codeOutputError
 	codeKillError
 	codeSpoolCancellationError
+	codeContainerMetricsFailed
+	codeMarshallingError
 )
 
 var (
@@ -31,6 +33,8 @@ var (
 	errOutputError            = [2]int{isolateErrCategory, codeOutputError}
 	errKillError              = [2]int{isolateErrCategory, codeKillError}
 	errSpoolCancellationError = [2]int{isolateErrCategory, codeSpoolCancellationError}
+	errContainerMetricsFailed = [2]int{isolateErrCategory, codeContainerMetricsFailed}
+	errMarshallingError       = [2]int{isolateErrCategory, codeMarshallingError}
 	errSpawnEAGAIN            = [2]int{systemCategory, codeSpawnEAGAIN}
 )
 

--- a/isolate/initialdispatch.go
+++ b/isolate/initialdispatch.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -317,7 +318,9 @@ func (d *initialDispatch) onSpawn(opts *cocaineProfile, name, executable string,
 
 func (d *initialDispatch) onContainersMetrics(uuidsQuery []string) (Dispatcher, error) {
 
-	log.G(d.ctx).Debugf("onContainersMetrics() Uuids query: %s", strings.Join(uuidsQuery, ", "))
+	log.G(d.ctx).Debugf("onContainersMetrics() Uuids query (len %d): %s", len(uuidsQuery), strings.Join(uuidsQuery, ", "))
+
+	startTime := time.Now()
 
 	sendMetricsFunc := func(metrics MetricsResponse) {
 		var (
@@ -340,7 +343,7 @@ func (d *initialDispatch) onContainersMetrics(uuidsQuery []string) (Dispatcher, 
 			d.stream.Error(d.ctx, replyMetricsError, errContainerMetricsFailed, err.Error())
 		}
 
-		log.G(d.ctx).Debug("containers metrics have been sent to runtime")
+		log.G(d.ctx).WithField("time", time.Since(startTime)).Debugf("Containers metrics have been sent to runtime, response length %d", len(metrics))
 	}
 
 	go func() {

--- a/isolate/initialdispatch.go
+++ b/isolate/initialdispatch.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"syscall"
 
@@ -316,7 +317,7 @@ func (d *initialDispatch) onSpawn(opts *cocaineProfile, name, executable string,
 
 func (d *initialDispatch) onContainersMetrics(uuidsQuery []string) (Dispatcher, error) {
 
-	log.G(d.ctx).Debugf("onContainersMetrics() Uuids query: %b", uuidsQuery)
+	log.G(d.ctx).Debugf("onContainersMetrics() Uuids query: %s", strings.Join(uuidsQuery, ", "))
 
 	sendMetricsFunc := func(metrics MetricsResponse) {
 		var (

--- a/isolate/isolate.go
+++ b/isolate/isolate.go
@@ -78,6 +78,11 @@ type (
 			Headers map[string]string `json:"headers,omitempty"`
 		} `json:"mtn,omitempty"`
 	}
+
+	MetricsPollConfig struct {
+		PollPeriod uint	`json:"period_sec"`
+		Args       json.RawMessage		`json:"args"`
+	}
 )
 
 func (d *JSONEncodedDuration) UnmarshalJSON(b []byte) error {

--- a/isolate/isolate.go
+++ b/isolate/isolate.go
@@ -28,12 +28,12 @@ type (
 		Inspect(ctx context.Context, workerid string) ([]byte, error)
 		Close() error
 
-		QueryMetrics(uuids []string) []MarkedContainerMetrics
+		QueryMetrics(uuids []string) []MarkedWorkerMetrics
 	}
 
 	ResponseStream interface {
 		Write(ctx context.Context, num uint64, data []byte) error
-		// packedPayload - MassagePacked data byte stream
+		// packedPayload - MessagePacked data byte stream
 		WriteMessage(ctx context.Context, num uint64, packedPayload []byte) error
 		Error(ctx context.Context, num uint64, code [2]int, msg string) error
 		Close(ctx context.Context, num uint64) error
@@ -80,8 +80,8 @@ type (
 	}
 
 	MetricsPollConfig struct {
-		PollPeriod string 				`json:"period"`
-		Args       json.RawMessage		`json:"args"`
+		PollPeriod string           `json:"period"`
+		Args       json.RawMessage  `json:"args"`
 	}
 )
 

--- a/isolate/isolate.go
+++ b/isolate/isolate.go
@@ -27,10 +27,14 @@ type (
 		Spawn(ctx context.Context, config SpawnConfig, output io.Writer) (Process, error)
 		Inspect(ctx context.Context, workerid string) ([]byte, error)
 		Close() error
+
+		QueryMetrics(uuids []string) []MarkedContainerMetrics
 	}
 
 	ResponseStream interface {
 		Write(ctx context.Context, num uint64, data []byte) error
+		// packedPayload - MassagePacked data byte stream
+		WriteMessage(ctx context.Context, num uint64, packedPayload []byte) error
 		Error(ctx context.Context, num uint64, code [2]int, msg string) error
 		Close(ctx context.Context, num uint64) error
 	}

--- a/isolate/isolate.go
+++ b/isolate/isolate.go
@@ -80,7 +80,7 @@ type (
 	}
 
 	MetricsPollConfig struct {
-		PollPeriod uint	`json:"period_sec"`
+		PollPeriod string 				`json:"period"`
 		Args       json.RawMessage		`json:"args"`
 	}
 )

--- a/isolate/porto/box.go
+++ b/isolate/porto/box.go
@@ -217,9 +217,11 @@ func NewBox(ctx context.Context, cfg isolate.BoxConfig, gstate isolate.GlobalSta
 
 	journalContent.Set(box.journal.String())
 
+	pollDuration, _ := time.ParseDuration(config.WorkersMetrics.PollPeriod)
+
 	go box.waitLoop(ctx)
 	go box.dumpJournalEvery(ctx, time.Minute)
-	go box.gatherLoopEvery(ctx, time.Duration(config.WorkersMetrics.PollPeriod) * time.Second)
+	go box.gatherLoopEvery(ctx, pollDuration)
 
 	return box, nil
 }

--- a/isolate/porto/metrics_gatherer.go
+++ b/isolate/porto/metrics_gatherer.go
@@ -1,0 +1,202 @@
+package porto
+
+import (
+    "fmt"
+    "golang.org/x/net/context"
+
+    "regexp"
+    "time"
+    "strconv"
+    "strings"
+
+    "github.com/noxiouz/stout/isolate"
+    "github.com/noxiouz/stout/pkg/log"
+
+    porto "github.com/yandex/porto/src/api/go"
+)
+
+var (
+    spacesRegexp, _ = regexp.Compile("[ ]+")
+    metricsNames = []string{
+        "cpu_usage",
+        "time",
+        "memory_usage",
+        "net_tx_bytes",
+        "net_rx_bytes",
+    }
+)
+
+const (
+    pairName = iota
+    pairVal
+    pairLen
+)
+
+type portoResponse map[string]map[string]porto.TPortoGetResponse
+type rawMetrics map[string]porto.TPortoGetResponse
+
+type netIfStat struct {
+    name string
+    bytesCount uint64
+}
+
+func parseStrUIntPair(eth string) (nstat netIfStat, err error) {
+    pair := strings.Split(eth, ": ")
+    if len(pair) == pairLen {
+        var v uint64
+        v, err = strconv.ParseUint(pair[pairVal], 10, 64)
+        if err != nil {
+            return
+        }
+
+        name := strings.Trim(pair[pairName], " ")
+        name  = spacesRegexp.ReplaceAllString(name, "_")
+
+        nstat = netIfStat{
+            name: name,
+            bytesCount: v,
+        }
+
+    } else {
+        err = fmt.Errorf("Failed to parse net record")
+    }
+
+    return
+}
+
+// TODO: check property Error/ErrorMsg fields
+func parseNetValues(val porto.TPortoGetResponse) (ifs []netIfStat) {
+    for _, eth := range strings.Split(val.Value, ";") {
+        nf, err := parseStrUIntPair(eth)
+        if err == nil {
+            ifs = append(ifs, nf)
+        }
+    }
+
+    return
+}
+
+// TODO: check property Error/ErrorMsg fields
+func parseUintProp(raw rawMetrics, propName string) (v uint64, err error) {
+    s, ok := raw[propName]
+    if !ok {
+        return 0, fmt.Errorf("no such prop in Porto: %s", propName)
+    }
+
+    v, err = strconv.ParseUint(s.Value, 10, 64)
+    return
+}
+
+func setUintField(field *uint64, raw rawMetrics, propName string) (err error) {
+    var v uint64
+    if v, err = parseUintProp(raw, propName); err == nil {
+        *field = v
+    }
+
+    return
+}
+
+func makeMetricsFromMap(raw rawMetrics) (m isolate.ContainerMetrics, err error) {
+
+    m = isolate.NewContainerMetrics()
+
+    if err = setUintField(&m.CpuUsageNs, raw, "cpu_usage"); err != nil {
+        return
+    }
+
+    if err = setUintField(&m.UptimeSec, raw, "time"); err != nil {
+        return
+    }
+
+    if err = setUintField(&m.Mem, raw, "memory_usage"); err != nil {
+        return
+    }
+
+
+    for _, netIf := range parseNetValues(raw["net_tx_bytes"]) {
+        v := m.Net[netIf.name]
+        v.TxBytes += netIf.bytesCount
+        m.Net[netIf.name] = v
+    }
+
+    for _, netIf := range parseNetValues(raw["net_rx_bytes"]) {
+        v := m.Net[netIf.name]
+        v.RxBytes += netIf.bytesCount
+        m.Net[netIf.name] = v
+    }
+
+    if m.UptimeSec > 0 {
+        cpu_usage_sec := float64(m.CpuUsageNs >> 10)
+        m.CpuLoad = cpu_usage_sec / float64(m.UptimeSec)
+    }
+
+    return
+}
+
+func parseMetrics(ctx context.Context, props portoResponse, idToUuid map[string]string) map[string]*isolate.ContainerMetrics {
+
+    metrics := make(map[string]*isolate.ContainerMetrics, len(props))
+
+    for id, rawMetrics := range props {
+        uuid, ok := idToUuid[id]
+        if !ok {
+            continue
+        }
+
+        if m, err := makeMetricsFromMap(rawMetrics); err != nil {
+            log.G(ctx).WithError(err).Error("Failed to parse raw metrics")
+            continue
+        } else {
+            metrics[uuid] = &m
+        }
+    }
+
+    return metrics
+}
+
+func (box *Box) gatherMetrics(ctx context.Context) {
+    log.G(ctx).Debug("Initializing Porto metrics gather loop")
+
+    idToUuid := box.getIdUuidMapping()
+
+    portoApi, err := portoConnect()
+    if err != nil {
+        log.G(ctx).WithError(err).Error("Failed to connect to Porto service")
+        return
+    }
+    defer func() {
+        if err := portoApi.Close(); err != nil {
+            log.G(ctx).WithError(err).Error("Failed close connection to Porto service")
+        }
+    }()
+
+    ids := make([]string, 0, len(idToUuid))
+    for id, _ := range idToUuid {
+        ids = append(ids, id)
+    }
+
+    var props portoResponse
+    props, err = portoApi.Get(ids, metricsNames)
+    if err != nil {
+        log.G(ctx).WithError(err).Error("Failed to connect to Porto service")
+        return
+    }
+
+    metrics := parseMetrics(ctx, props, idToUuid)
+    box.SetMetricsMapping(metrics)
+}
+
+func (box *Box) gatherLoop(ctx context.Context, interval time.Duration) {
+    log.G(ctx).Debug("Initializing Porto metrics gather loop")
+
+    t := time.NewTicker(interval)
+    for {
+        select {
+        case <- ctx.Done():
+            return
+        case <- t.C:
+            log.G(ctx).Debug("Porto metrics gather iteration")
+            box.gatherMetrics(ctx)
+        }
+    }
+}

--- a/isolate/process/box.go
+++ b/isolate/process/box.go
@@ -129,13 +129,13 @@ func NewBox(ctx context.Context, cfg isolate.BoxConfig, gstate isolate.GlobalSta
 		box.sigchldHandler()
 	}()
 
-	wrkMetricsConf, ok := cfg["workersmetrics"]
-	if ok {
-		// TODO: increase box working group count?
+	// TODO: increase box working group count?
+	if wrkMetricsConf, ok := cfg["workersmetrics"]; ok {
 		if metConf, err := getMetricsPollConf(wrkMetricsConf); err != nil {
 			log.G(ctx).Infof("Failed to read `workersmetrics` field, using defaults. Err: %v", err)
 		} else {
-			go box.gatherLoopEvery(ctx, time.Duration(metConf.PollPeriod) * time.Second)
+			duration, _ := time.ParseDuration(metConf.PollPeriod)
+			go box.gatherLoopEvery(ctx, duration)
 		}
 	}
 

--- a/isolate/process/box.go
+++ b/isolate/process/box.go
@@ -243,7 +243,7 @@ func (b *Box) Spawn(ctx context.Context, config isolate.SpawnConfig, output io.W
 	}
 	b.children[pr.cmd.Process.Pid] = workerInfo{
 		Cmd:  pr.cmd,
-		uuid: "",
+		uuid: config.Args["--uuid"],
 	}
 	b.mu.Unlock()
 
@@ -292,6 +292,10 @@ func (b *Box) Inspect(ctx context.Context, worker string) ([]byte, error) {
 	}
 	b.mu.Unlock()
 	return []byte("{}"), nil
+}
+
+func (b *Box) QueryMetrics(uuids []string) (r []isolate.MarkedContainerMetrics) {
+	return
 }
 
 func (b *Box) fetch(ctx context.Context, appname string) ([]byte, error) {

--- a/isolate/process/metrics_gatherer.go
+++ b/isolate/process/metrics_gatherer.go
@@ -1,0 +1,132 @@
+// TODO:
+//  - log timings
+//
+package process
+
+import (
+    "context"
+    "regexp"
+    "syscall"
+    "time"
+
+    "github.com/noxiouz/stout/isolate"
+    "github.com/noxiouz/stout/pkg/log"
+
+    gopsutil "github.com/shirou/gopsutil/process"
+    gopsnet  "github.com/shirou/gopsutil/net"
+)
+
+const eachIface = true
+
+var (
+    pageSize = uint64(syscall.Getpagesize())
+    spacesRegexp, _ = regexp.Compile("[ ]+")
+)
+
+func makeNiceName(name string) string {
+    return spacesRegexp.ReplaceAllString(name, "_")
+}
+
+func generateNetStat(net []gopsnet.IOCountersStat) (out map[string]isolate.NetStat) {
+    out = make(map[string]isolate.NetStat, len(net))
+
+    for _, c := range net {
+        out[c.Name] = isolate.NetStat{
+            RxBytes: c.BytesRecv,
+            TxBytes: c.BytesSent,
+        }
+    }
+
+    return
+}
+
+func readProcStat(pid int, startTime time.Time, now time.Time) (isolate.ContainerMetrics, error) {
+    uptime := now.Sub(startTime).Seconds()
+
+    var (
+        process *gopsutil.Process
+
+        cpuload float64
+        // netstat []gopsnet.IOCountersStat
+        memstat *gopsutil.MemoryInfoStat
+
+        errStub isolate.ContainerMetrics
+        err error
+    )
+
+    if process, err = gopsutil.NewProcess(int32(pid)); err != nil {
+        return errStub, err
+    }
+
+    if cpuload, err = process.CPUPercent(); err != nil {
+        return errStub, err
+    }
+
+    if memstat, err = process.MemoryInfo(); err != nil {
+        return errStub, err
+    }
+
+    //
+    // TODO:
+    //   There is no per process network stat yet in gopsutil,
+    //   Per process view of system stat is in `netstat` slice.
+    //
+    //   Most commonly used (the only?) way to take per process network
+    //   stats is by libpcap.
+    //
+    // if netstat, err = process.NetIOCounters(eachIface); err != nil {
+    //
+    if _, err = process.NetIOCounters(eachIface); err != nil {
+        return errStub, err
+    }
+
+    return isolate.ContainerMetrics{
+        UptimeSec: uint64(uptime),
+        // CpuUsageSec:
+
+        CpuLoad: cpuload,
+        Mem: memstat.VMS,
+        // Per process net io stat is unimplemented.
+        // Net: generateNetStat(netstat),
+    }, nil
+}
+
+func (b *Box) gatherMetrics(ctx context.Context) {
+    ids := b.getIdUuidMapping()
+    metrics := make(map[string]*isolate.ContainerMetrics, len(ids))
+
+    now := time.Now()
+
+    for pid, taskInfo := range ids {
+        state, err := readProcStat(pid, taskInfo.startTime, now)
+        if err != nil {
+            log.G(ctx).Errorf("Failed to read stat for process with pid %d", pid)
+            continue
+        }
+
+        metrics[taskInfo.uuid] = &state
+    }
+
+    b.setMetricsMapping(metrics)
+}
+
+func (b *Box) gatherLoopEvery(ctx context.Context, interval time.Duration) {
+
+    if interval == 0 {
+        log.G(ctx).Info("Process metrics gatherer disabled (use config to setup)")
+        return
+    }
+
+    log.G(ctx).Infof("Initializing Process metrics gather loop with %v duration", interval)
+
+    for {
+        select {
+        case <- ctx.Done():
+            return
+        case <-time.After(interval):
+            b.gatherMetrics(ctx)
+        }
+    }
+
+    log.G(ctx).Info("Cancelling Process metrics loop")
+}

--- a/isolate/process/metrics_gatherer.go
+++ b/isolate/process/metrics_gatherer.go
@@ -86,6 +86,7 @@ func readProcStat(pid int, startTime time.Time, now time.Time) (isolate.Containe
 
         CpuLoad: cpuload,
         Mem: memstat.VMS,
+
         // Per process net io stat is unimplemented.
         // Net: generateNetStat(netstat),
     }, nil


### PR DESCRIPTION
**For preliminary review.**

Gopher gurus, @3Hren, @antmat, PTAL.

Metrics (for _porto_ and _procfs_):
 - _cpu load_: percents
 - _memory:_ bytes count
- _network_: tx, rx bytes count (for porto only, but yet system wide stat provided)

## Setup (via config file)
```
{
...
  "isolate": { 
      "porto" {
            "type": "porto",
            "args": {
                "workersmetrics": {
                    "period": "5s"
                }
            }
        },
        "process": {
            "type": "process",
            "args": {
                "workersmetrics": {
                    "period": "5s"
                }
            }
        },
       ...
  }
}
```
Zero poll period (default) switches metrics poll off.

TODO:
 - [ ] per worker network stat (seems not trivial to implement)
 - [ ] docker isolation stats (not in priority, separate PR)
 - [ ] tests